### PR TITLE
Ftr add traverse ns calls

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -40,6 +40,8 @@ add_coarct_exe(func-decl-lister-am FuncListerAM.cc )
 
 add_coarct_exe(global-detect GlobalDetect.cc )
 
+add_coarct_exe(list-member-calls ListCXXMemberCalls.cc )
+
 # add_coarct_exe(while-loop-detect WhileLoopFinder.cc )
 
 # add_coarct_exe(loop-convert LoopConvert.cpp

--- a/apps/ListCXXMemberCalls.cc
+++ b/apps/ListCXXMemberCalls.cc
@@ -1,0 +1,77 @@
+// ListCXXMemberCalls.cc
+// Oct 26, 2018
+// (c) Copyright 2018 LANSLLC, all rights reserved
+
+/* Demonstrate AST Matcher to list all cxx member calls in a namespace.
+ * This was inspired by Stack Overflow #52993315 */
+
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+#include "clang/ASTMatchers/ASTMatchers.h"
+#include "clang/Tooling/CommonOptionsParser.h"
+#include "clang/Tooling/Tooling.h"
+#include "dump_things.h"
+#include "llvm/Support/CommandLine.h"
+#include "utilities.h"
+#include <iostream>
+
+using namespace clang::tooling;
+using namespace llvm;
+using namespace clang::ast_matchers;
+
+/* Make a matcher for call expressions in namespace ns_name */
+auto
+mk_call_expr_matcher(std::string const & ns_name)
+{
+  return cxxMemberCallExpr(hasAncestor(namespaceDecl(hasName(ns_name))))
+      .bind("call");
+}
+
+/* CallPrinter::run() will be called when a match is found */
+struct CallPrinter : public MatchFinder::MatchCallback {
+  void run(MatchFinder::MatchResult const & result) override
+  {
+    using namespace clang;
+    SourceManager & sm(result.Context->getSourceManager());
+    CXXMemberCallExpr const * call =
+        result.Nodes.getNodeAs<CXXMemberCallExpr>("call");
+    if(call) {
+      num_calls++;
+      auto const method_name(call->getMethodDecl()->getNameAsString());
+      auto const callee_name(call->getRecordDecl()->getNameAsString());
+      std::cout << "Method '" << method_name << "' invoked by object of type '"
+                << callee_name << "' at "
+                << corct::locationAsString(call->getBeginLoc(), &sm) << "\n";
+    }
+    else {
+      corct::check_ptr(call, "call");
+    }
+    return;
+  }  // run
+
+  uint32_t num_calls = 0;
+};  // CallPrinter
+
+static llvm::cl::OptionCategory mem_cat("list-member-call options");
+
+static cl::opt<std::string> ns_name_string("ns",
+                                           cl::desc("namespace"),
+                                           cl::value_desc("ns"),
+                                           cl::cat(mem_cat),
+                                           cl::init(""));
+
+int
+main(int argc, const char ** argv)
+{
+  CommonOptionsParser OptionsParser(argc, argv, mem_cat);
+  ClangTool Tool(OptionsParser.getCompilations(),
+                 OptionsParser.getSourcePathList());
+  CallPrinter cp;
+  MatchFinder finder;
+
+  finder.addMatcher(mk_call_expr_matcher(ns_name_string), &cp);
+  int rslt = Tool.run(newFrontendActionFactory(&finder).get());
+  std::cout << "Reported " << cp.num_calls << " member calls\n";
+  return rslt;
+}
+
+// End of file

--- a/test/lib/test_input_ns_decl.cpp
+++ b/test/lib/test_input_ns_decl.cpp
@@ -1,11 +1,3 @@
-struct C{
-  void a1(){}
-};
-
-struct D{
-  void b1(C &a){ return a.a1(); }
-};
-
 namespace N{
 struct A{
   void a1(){}
@@ -22,6 +14,14 @@ void g(B &b){
 }
 
 } // N::
+
+struct C{
+  void a1(){}
+};
+
+struct D{
+  void b1(C &a){ return a.a1(); }
+};
 
 namespace N2{
 struct A{

--- a/test/lib/test_input_ns_decl.cpp
+++ b/test/lib/test_input_ns_decl.cpp
@@ -1,0 +1,41 @@
+struct C{
+  void a1(){}
+};
+
+struct D{
+  void b1(C &a){ return a.a1(); }
+};
+
+namespace N{
+struct A{
+  void a1(){}
+};
+
+struct B{
+  void b1(A &a){ return a.a1(); }
+};
+
+void g(B &b){
+  A a;
+  b.b1(a);
+  return;
+}
+
+} // N::
+
+namespace N2{
+struct A{
+  void a1(){}
+};
+
+struct B{
+  void b1(A &a){ return a.a1(); }
+};
+
+void g(B &b){
+  A a;
+  b.b1(a);
+  return;
+}
+
+} // N2::


### PR DESCRIPTION
Add example that reports all C++ member calls within a particular namespace.